### PR TITLE
Restores Craft template path variable to it's original value

### DIFF
--- a/services/AmForms_FormsService.php
+++ b/services/AmForms_FormsService.php
@@ -217,6 +217,9 @@ class AmForms_FormsService extends BaseApplicationComponent
         $fieldTemplateInfo = craft()->amForms->getDisplayTemplateInfo('field', $form->fieldTemplate);
         $templatePath = $fieldTemplateInfo['path'];
 
+        // get the current templates path so we can restore it at the end of this function
+        $oldTemplatesPath = craft()->path->getTemplatesPath();
+
         // Do we have the current form fields?
         if (! isset($this->_fields[$form->id])) {
             $this->_fields[$form->id] = array();
@@ -253,6 +256,9 @@ class AmForms_FormsService extends BaseApplicationComponent
             }
         }
 
+        // restore the templates path variable to it's original value
+        craft()->path->setTemplatesPath($oldTemplatesPath);
+
         // Return field!
         if (isset($this->_fields[$form->id][$handle])) {
             return new \Twig_Markup($this->_fields[$form->id][$handle], craft()->templates->getTwig()->getCharset());
@@ -280,6 +286,9 @@ class AmForms_FormsService extends BaseApplicationComponent
         $fieldTemplateInfo = craft()->amForms->getDisplayTemplateInfo('field', $form->fieldTemplate);
         $templatePath = $fieldTemplateInfo['path'];
 
+        // get the current templates path so we can restore it at the end of this function
+        $oldTemplatesPath = craft()->path->getTemplatesPath();
+        
         foreach ($form->getFieldLayout()->getTabs() as $tab) {
             // Tab information
             $tabs[$tab->id] = array(
@@ -318,6 +327,10 @@ class AmForms_FormsService extends BaseApplicationComponent
             }
         }
 
+
+        // restore the templates path variable to it's original value
+        craft()->path->setTemplatesPath($oldTemplatesPath);
+        
         // Build tab HTML
         $variables = array(
             'form'    => $form,


### PR DESCRIPTION
The methods displayField and displayForm change the craft()->path to include plugin templates but do not restore the value before the methods returns. This causes an 'cannot find template error' in my site specific templates where I include other templates after calling this function. See http://buildwithcraft.com/docs/plugins/templates for an explanation.
